### PR TITLE
Permission changes to CKAN role

### DIFF
--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -34,7 +34,6 @@
     # virtualenv is accessible.  
     PATH: /usr/local/bin:/bin:/usr/bin
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 - name: pip install CKAN requirements
   pip:
@@ -45,7 +44,6 @@
     # time gathering facts. We could just use anisble_env.PATH
     PATH: /usr/pgsql-9.3/bin:/usr/local/bin:/bin:/usr/bin
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 # TODO: Write a custom module that installs the custom plugins
 - name: pip install CKAN any custom plugins
@@ -57,7 +55,6 @@
   with_items: ckan_custom_plugins
   when: ckan_custom_plugins is defined
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 - name: check if custom plugin has requirements.txt file
   stat: path="{{ckan_venv}}/src/{{item.egg_name|regex_replace('_', '-')}}/requirements.txt"
@@ -65,7 +62,6 @@
   when: ckan_custom_plugins is defined
   register: plugins_requirements
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 - name: pip install the requirements of custom plugins
   pip:
@@ -74,7 +70,6 @@
   with_items: plugins_requirements.results
   when: item.stat.exists
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 - name: create CKAN config directory
   file:
@@ -106,7 +101,6 @@
     dest="{{ckan_config_dir}}/config.ini"
   notify: restart apache
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 - name: set read-only ckan user
   shell: source {{ckan_venv}}/bin/activate && paster --plugin=ckan datastore set-permissions -c {{ckan_config_dir}}/config.ini | sudo -u postgres psql --set ON_ERROR_STOP=1
@@ -137,7 +131,6 @@
     mode=0755
   notify: restart apache
   sudo: yes
-  sudo_user: "{{ckan_user}}"
 
 - name: create CKAN apache config file
   template:

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -33,6 +33,8 @@
     # to ensure /usr/local/bin is in the path so that 
     # virtualenv is accessible.  
     PATH: /usr/local/bin:/bin:/usr/bin
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 - name: pip install CKAN requirements
   pip:
@@ -42,6 +44,8 @@
     # This is a bit of a hack so that we don't have to spend
     # time gathering facts. We could just use anisble_env.PATH
     PATH: /usr/pgsql-9.3/bin:/usr/local/bin:/bin:/usr/bin
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 # TODO: Write a custom module that installs the custom plugins
 - name: pip install CKAN any custom plugins
@@ -52,12 +56,16 @@
     extra_args="-e"
   with_items: ckan_custom_plugins
   when: ckan_custom_plugins is defined
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 - name: check if custom plugin has requirements.txt file
   stat: path="{{ckan_venv}}/src/{{item.egg_name|regex_replace('_', '-')}}/requirements.txt"
   with_items: ckan_custom_plugins
   when: ckan_custom_plugins is defined
   register: plugins_requirements
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 - name: pip install the requirements of custom plugins
   pip:
@@ -65,6 +73,8 @@
     virtualenv="{{ckan_venv}}"
   with_items: plugins_requirements.results
   when: item.stat.exists
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 - name: create CKAN config directory
   file:
@@ -95,6 +105,8 @@
     src="config.ini.j2"
     dest="{{ckan_config_dir}}/config.ini"
   notify: restart apache
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 - name: set read-only ckan user
   shell: source {{ckan_venv}}/bin/activate && paster --plugin=ckan datastore set-permissions -c {{ckan_config_dir}}/config.ini | sudo -u postgres psql --set ON_ERROR_STOP=1
@@ -124,6 +136,8 @@
     dest="{{ckan_config_dir}}/apache.wsgi"
     mode=0755
   notify: restart apache
+  sudo: yes
+  sudo_user: "{{ckan_user}}"
 
 - name: create CKAN apache config file
   template:
@@ -145,7 +159,6 @@
     - "{{ckan_log_dir}}"
   notify: restart apache
   sudo: yes
-
 
 - name: create crontab for sending activity stream emails
   cron: name="ckan_send_emails"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -123,6 +123,7 @@
     src={{ckan_venv}}/src/ckan/who.ini
     dest=/etc/ckan/default/who.ini
     state=link
+  sudo: yes
 
 - name: create CKAN wsgi file
   template: 


### PR DESCRIPTION
These changes are needed because of working with particularly restrictive environments.  For example, if the umask is set to 077 then we cannot rely on the non-sudo user having permission to read the directory.  The easier workaround here is to run most of these commands as sudo and then chown the directories that we need to afterwards.  In the ideal world we would figure out exactly the right tweaks to the users and their permissions to make it all work, but realistically that approach will take more time than it's worth.  

Reviewers: 
- @marcesher 
