### PR TITLE
Changes to break out Solr as a separate service

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,7 +93,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # The generated inventory file is located at:
     # .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory
     ansible.groups = {
-        "local" => ["default"]
+        "local" => ["default"],
+        "search" => ["default"],
+        "db" => ["default"],
+        "app" => ["default"]
     }
   end
   

--- a/provisioners/provision.yml
+++ b/provisioners/provision.yml
@@ -1,15 +1,23 @@
 ---
 # Provisions the CKAN VM from scratch
 
-- hosts: local
+- hosts: db
   gather_facts: False
   roles:
     - postgres
     - postgres-ckan
+
+- hosts: search
+  gather_facts: False
+  roles:
     - solr
+
+- hosts: local
+  gather_facts: False
+  roles:
     - iptables
 
-- hosts: all
+- hosts: app
   gather_facts: False
   roles:
     - python27

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -52,6 +52,11 @@
     virtualenv="{{ckan_venv}}"
     virtualenv_site_packages=no
     extra_args="-e"
+  environment: 
+    # Depending on the user running this command, we need
+    # to ensure /usr/local/bin is in the path so that 
+    # virtualenv is accessible.  
+    PATH: /usr/local/bin:/bin:/usr/bin
   with_items: ckan_custom_plugins
   when: ckan_custom_plugins is defined
   sudo: yes

--- a/provisioners/roles/iptables/tasks/main.yml
+++ b/provisioners/roles/iptables/tasks/main.yml
@@ -2,9 +2,10 @@
 # tasks file for iptables
 
 # Stop iptables because it blocks some of the necessary ports for 
-# ckan to function properly.
+# ckan to function properly. We only run this locally...
 # TODO: Find an actual solution to this problem instead of disabling
 # iptables
 - name: stop iptables
   service: name=iptables state=stopped
+  when: groups.has_key('local') and inventory_hostname in groups.local
   sudo: yes

--- a/provisioners/roles/solr/tasks/main.yml
+++ b/provisioners/roles/solr/tasks/main.yml
@@ -36,17 +36,11 @@
     creates=/tmp/solr-4.9.1/
     chdir=/tmp
   sudo: yes
-  sudo_user: "{{solr_user}}"
 
 - name: copy solr binary to solr home
   command: cp -R /tmp/solr-4.9.1/example/. {{solr_home}}
     creates="{{solr_home}}/README.txt"
   sudo: yes
-  sudo_user: "{{solr_user}}"
-
-# - name: chown the solr home directory
-#   command: chown -R {{solr_user}}:{{solr_group}} {{solr_home}}
-#   sudo: yes
 
 - name: create solr service entry
   template: 
@@ -68,7 +62,10 @@
     dest="{{solr_home}}/solr/collection1/conf/schema.xml"
   notify: restart solr
   sudo: yes
-  sudo_user: "{{solr_user}}"
+
+- name: chown the solr home directory
+  command: chown -R {{solr_user}}:{{solr_group}} {{solr_home}}
+  sudo: yes
 
 - name: start solr service
   service: name=solr state=started enabled=yes


### PR DESCRIPTION
Updated the provision playbook to let Solr be a separate service.  This enables us to deploy to it separately from the app.  Tossed in a couple of changes to the solr role that were required to get this to work out, as well as a structural change to the iptables role to ensure it only runs locally.  

Reviewers:
- @marcesher 
