### PR TITLE
Sam discovered that if you reload the box it will start up iptables. 

### DIFF
--- a/provisioners/roles/iptables/tasks/main.yml
+++ b/provisioners/roles/iptables/tasks/main.yml
@@ -6,6 +6,6 @@
 # TODO: Find an actual solution to this problem instead of disabling
 # iptables
 - name: stop iptables
-  service: name=iptables state=stopped
+  service: name=iptables state=stopped enabled=false
   when: groups.has_key('local') and inventory_hostname in groups.local
   sudo: yes


### PR DESCRIPTION
 So I'm adding enabled=false to iptables so that it doesn't restart when we reload the box

@marcesher can you please give this a thumbs up?  
