### PR TITLE
Only allow web registration on local installs

### DIFF
--- a/provisioners/group_vars/local
+++ b/provisioners/group_vars/local
@@ -12,6 +12,7 @@ postgres_login_password: your-super-secure-ckan-password!23
 solr_user: solr
 solr_user_password: $6$rounds=100000$IGDBTmZvVy2T1Edh$jNd.4ZnMV2woq.O9yDfneeJNDdQ..QDGLW897ymS9zQIiM7qiu40PeRPIioArDQCJOf1qDjV1yeWCjOeI/SFA/
 jetty_user: solr
+ckan_create_user_via_web: True 
 ckan_custom_plugins:
   - name: ckanext_cfpb_extrafields
     egg_name: ckanext_cfpb_extrafields

--- a/provisioners/roles/ckan/defaults/main.yml
+++ b/provisioners/roles/ckan/defaults/main.yml
@@ -34,3 +34,6 @@ ckan_email_flush_interval: "0,30"
 
 # Plugin Settings
 ckan_plugins: stats text_preview recline_preview datastore
+
+# User Registration Settings (registration only allowed on local machines without LDAP)
+ckan_create_user_via_web: False

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -68,7 +68,7 @@ ckan.auth.user_create_organizations = false
 ckan.auth.user_delete_groups = false
 ckan.auth.user_delete_organizations = false
 ckan.auth.create_user_via_api = false
-ckan.auth.create_user_via_web = true
+ckan.auth.create_user_via_web = {{ckan_create_user_via_web}}
 ckan.auth.roles_that_cascade_to_sub_groups = admin
 
 


### PR DESCRIPTION
This hides the registration button outside of local (where users need to be able to register themselves because LDAP is not available).
