### PR TITLE
Fix postgres installation

### DIFF
--- a/provisioners/roles/postgres/tasks/main.yml
+++ b/provisioners/roles/postgres/tasks/main.yml
@@ -5,8 +5,28 @@
     dest=/etc/yum.repos.d/CentOS-Base.repo
   sudo: yes
 
+- name: install cert utilities
+  yum: 
+    name: ca-certificates
+    state: latest
+  sudo: yes
+
+- name: Enable dynamic CA configuration
+  shell: update-ca-trust force-enable
+  sudo: yes
+
+- name: get letsencrypt root cert
+  shell: wget https://letsencrypt.org/certs/isrgrootx1.pem
+  args:
+    chdir: /etc/pki/ca-trust/source/anchors/
+  sudo: yes
+
+- name: Update certs
+  shell: update-ca-trust extract
+  sudo: yes
+
 - name: ensure PGDG Yum repo is installed
-  shell: rpm -Uvh http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-1.noarch.rpm 
+  shell: rpm -Uvh http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm 
     creates=/etc/yum.repos.d/pgdg-94-centos.repo
   sudo: yes
 

--- a/provisioners/roles/postgres/tasks/main.yml
+++ b/provisioners/roles/postgres/tasks/main.yml
@@ -11,20 +11,6 @@
     state: latest
   sudo: yes
 
-- name: Enable dynamic CA configuration
-  shell: update-ca-trust force-enable
-  sudo: yes
-
-- name: get letsencrypt root cert
-  shell: wget https://letsencrypt.org/certs/isrgrootx1.pem
-  args:
-    chdir: /etc/pki/ca-trust/source/anchors/
-  sudo: yes
-
-- name: Update certs
-  shell: update-ca-trust extract
-  sudo: yes
-
 - name: ensure PGDG Yum repo is installed
   shell: rpm -Uvh http://yum.postgresql.org/9.4/redhat/rhel-6-x86_64/pgdg-centos94-9.4-3.noarch.rpm 
     creates=/etc/yum.repos.d/pgdg-94-centos.repo


### PR DESCRIPTION
* rpm url needed to be updated to new version
* https://postgres.org now uses an SSL cert signed by letsencrypt, which
  is not trusted by default on centos6. Added steps to install that cert.