### PR TITLE
Add Mesos Installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ Installation instructions can be found here: http://docs.vagrantup.com/v2/instal
 To start the vagrant box: `vagrant up`  
 To stop the vagrant box: `vagrant halt`  
 
+## Installing on Aurora
+If you would like to install ckan onto a locally running instance of [Aurora](https://github.com/cfpb/aurora), follow the steps below.
+Since each Aurora app consists of a single ephemeral foreground process, this technique relies on installing CKAN the traditional way first and using its instance of PostgreSQL/Solr with an Apache process running on Mesos via Marathon.
+
+1. `cd` into this repo and run `vagrant up`
+2. Create SSH tunnels to the PostgreSQL/Solr instances: `vagrant ssh -- -L 8983:localhost:8983 -L 5432:localhost:5432`
+3. From the aurora repo, open an ssh tunnel to marathon: `vagrant ssh mesos_master_1 -- -L 8000:localhost:8080`
+4. Within the ssh tunnel, find your gateway IP by running `netstat -nr | grep default`
+5. Visit [localhost:8080](http://localhost:8080) to access the marathon UI and make a new app
+6. Edit the app's config, click the "json" toggle in the upper right, and paste the json from `marathon_app.json` (located in the same directory as this readme). Update any instances of `10.0.2.2` with the gateway IP you noted in step 4.
+7. Upon saving the config, you'll be prompted to (re)deploy the application. Do so and give it time to install (~10 minutes?)
+8. Download the stdout/stderr files in marathon and briefly scan them for errors
+9. Within those stdout/stderr, note the long directory that everything is being put into (`MESOS_SANDBOX`). Try `vagrant ssh mesos_agent_1 -- -L 8888:localhost:8888` and within that machine `ls <path/to/sandbox>`. If the file does not exist, kill the ssh and retry with `mesos_agent_2` and `mesos_agent_3` until you've found the agent that is running the application.
+10. Try visiting [localhost:8888](http://localhost:8888) and ensure that you can see the Data Catalog page.
+11. If you encounter an apache error page, go to your ssh session with the mesos agent and look for details in the logs at `/path/to/sandbox/httpd`
+
 ## Getting Started
 For information about how to use CKAN, please see the [official documentation](http://docs.ckan.org/en/latest/user-guide.html)
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,15 @@ To stop the vagrant box: `vagrant halt`
 If you would like to install ckan onto a locally running instance of [Aurora](https://github.com/cfpb/aurora), follow the steps below.
 Since each Aurora app consists of a single ephemeral foreground process, this technique relies on installing CKAN the traditional way first and using its instance of PostgreSQL/Solr with an Apache process running on Mesos via Marathon.
 
-1. `cd` into this repo and run `vagrant up`
+1. `cd` into the `provisioners/` folder in this repo and run `vagrant up`
 2. Create SSH tunnels to the PostgreSQL/Solr instances: `vagrant ssh -- -L 8983:localhost:8983 -L 5432:localhost:5432`
-3. From the aurora repo, open an ssh tunnel to marathon: `vagrant ssh mesos_master_1 -- -L 8000:localhost:8080`
-4. Within the ssh tunnel, find your gateway IP by running `netstat -nr`
-5. Visit [localhost:8000](http://localhost:8000) to access the marathon UI and make a new app
-6. Edit the app's config, click the "json" toggle in the upper right, and paste the json from `marathon_app.json` (located in the same directory as this readme). Update any instances of `10.0.2.2` with the gateway IP you noted in step 4.
-7. Upon saving the config, you'll be prompted to (re)deploy the application. Do so and give it time to install (~10 minutes?)
-8. Download the stdout/stderr files in marathon and briefly scan them for errors
-9. Within those stdout/stderr, note the long directory that everything is being put into (`MESOS_SANDBOX`). Try `vagrant ssh mesos_agent_1 -- -L 8888:localhost:8888` and within that machine `ls <path/to/sandbox>`. If the file does not exist, kill the ssh and retry with `mesos_agent_2` and `mesos_agent_3` until you've found the agent that is running the application.
-10. Try visiting [localhost:8888](http://localhost:8888) and ensure that you can see the Data Catalog page.
-11. If you encounter an apache error page, go to your ssh session with the mesos agent and look for details in the logs at `/path/to/sandbox/httpd`
+3. Visit [10.0.1.31:8080](http://10.0.1.31:8080) to access the marathon UI and make a new app
+4. Edit the app's config, click the "json" toggle in the upper right, and paste the json from `marathon_app.json` (located in the same directory as this readme).
+5. Upon saving the config, you'll be prompted to (re)deploy the application. Do so and give it time to install (~10 minutes?)
+6. Open the Mesos UI at [10.0.1.31:5000](http://10.0.1.31:5000). Locate your job under the "Active Tasks" section and click its "Sandbox" link.
+7. Click the "stdout" link and confirm that the bottom says `PLAY RECAP` and that you see `failed=0`. If there is no play recap yet, you probably need to wait for ansible to finish running
+8. Go back to the [Marathon UI](http://10.0.1.31:8080) and locate your task. Click the link undereath the ID (something like '10.0.1.34:31029').
+9. This should open the Data Catalog in a new tab. If you receive an error page, go back to the sandbox and check `stdout`, `stderr` and `httpd/apache.error.log` for error messages.
 
 ## Getting Started
 For information about how to use CKAN, please see the [official documentation](http://docs.ckan.org/en/latest/user-guide.html)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Since each Aurora app consists of a single ephemeral foreground process, this te
 3. Visit [10.0.1.31:8080](http://10.0.1.31:8080) to access the marathon UI and make a new app
 4. Edit the app's config, click the "json" toggle in the upper right, and paste the json from `marathon_app.json` (located in the same directory as this readme).
 5. Upon saving the config, you'll be prompted to (re)deploy the application. Do so and give it time to install (~10 minutes?)
-6. Open the Mesos UI at [10.0.1.31:5000](http://10.0.1.31:5000). Locate your job under the "Active Tasks" section and click its "Sandbox" link.
+6. Open the Mesos UI at [10.0.1.31:5050](http://10.0.1.31:5050). Locate your job under the "Active Tasks" section and click its "Sandbox" link.
 7. Click the "stdout" link and confirm that the bottom says `PLAY RECAP` and that you see `failed=0`. If there is no play recap yet, you probably need to wait for ansible to finish running
 8. Go back to the [Marathon UI](http://10.0.1.31:8080) and locate your task. Click the link undereath the ID (something like '10.0.1.34:31029').
 9. This should open the Data Catalog in a new tab. If you receive an error page, go back to the sandbox and check `stdout`, `stderr` and `httpd/apache.error.log` for error messages.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ If you want to upgrade the version of ckan, follow the instructions in the [CKAN
 
 Note that you must upgrade one minor version at a time (you can't go straight from 2.3 to 2.5, but instead must do `2.3 -> 2.4 -> 2.5`).
 
+Furthermore, there is a bug in version 2.5.0, so the actual list of tags should be: `ckan-2.3` -> `ckan-2.4.0` -> `ckan-2.5.3` -> `ckan-2.6.0`.
+
 ## Developers
 
 Check out the [Guide to Extending](http://docs.ckan.org/en/latest/extensions/tutorial.html) in the offical documentation

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Since each Aurora app consists of a single ephemeral foreground process, this te
 1. `cd` into this repo and run `vagrant up`
 2. Create SSH tunnels to the PostgreSQL/Solr instances: `vagrant ssh -- -L 8983:localhost:8983 -L 5432:localhost:5432`
 3. From the aurora repo, open an ssh tunnel to marathon: `vagrant ssh mesos_master_1 -- -L 8000:localhost:8080`
-4. Within the ssh tunnel, find your gateway IP by running `netstat -nr | grep default`
-5. Visit [localhost:8080](http://localhost:8080) to access the marathon UI and make a new app
+4. Within the ssh tunnel, find your gateway IP by running `netstat -nr`
+5. Visit [localhost:8000](http://localhost:8000) to access the marathon UI and make a new app
 6. Edit the app's config, click the "json" toggle in the upper right, and paste the json from `marathon_app.json` (located in the same directory as this readme). Update any instances of `10.0.2.2` with the gateway IP you noted in step 4.
 7. Upon saving the config, you'll be prompted to (re)deploy the application. Do so and give it time to install (~10 minutes?)
 8. Download the stdout/stderr files in marathon and briefly scan them for errors

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ For information about how to use CKAN, please see the [official documentation](h
 **Customizing Look and Feel**  
 See the section on [Customizing Look and Feel](http://docs.ckan.org/en/latest/sysadmin-guide.html#customizing-look-and-feel) in the official documentation
 
+## Useful commands
+The ckan docs contain several commands that are useful for administering the ckan instance. Some of them are listed here for convenience:
+
+Make a user an admin:
+
+    source /ckan/default/bin/activate && cd /ckan/default/src/ckan && paster sysadmin add <username> -c /ckan/config/default/config.ini
+
+Re-index solr  (required after upgrade)
+
+    source /ckan/default/bin/activate && cd /ckan/default/src/ckan && paster search-index rebuild -r --config=/ckan/config/default/config.ini
+
+## Upgrading CKAN
+If you want to upgrade the version of ckan, follow the instructions in the [CKAN Docs](http://docs.ckan.org/en/latest/maintaining/upgrading/upgrade-source.html).
+
+Note that you must upgrade one minor version at a time (you can't go straight from 2.3 to 2.5, but instead must do `2.3 -> 2.4 -> 2.5`).
+
 ## Developers
 
 Check out the [Guide to Extending](http://docs.ckan.org/en/latest/extensions/tutorial.html) in the offical documentation

--- a/hosts/mesos_host
+++ b/hosts/mesos_host
@@ -1,0 +1,7 @@
+localhost ansible_connection=local
+
+[mesos]
+localhost
+
+[app]
+localhost

--- a/marathon_app.json
+++ b/marathon_app.json
@@ -9,7 +9,7 @@
     "ANSIBLE_CONFIG": "ansible-mesos.cfg",
     "CKAN_DATASTORE_DB_USER": "datastore_default",
     "CKAN_SOLR_URL": "http://10.0.2.2:8983/solr",
-    "CKAN_SITE_URL": "http://localhost:$PORT0",
+    "CKAN_SITE_URL": "http://$HOST:$PORT0",
     "CKAN_DATASTORE_DB_NAME": "ckan_datastore",
     "CKAN_DB_USER": "ckan_default",
     "CKAN_POSTGRES_HOST": "10.0.2.2",

--- a/marathon_app.json
+++ b/marathon_app.json
@@ -9,6 +9,7 @@
     "ANSIBLE_CONFIG": "ansible-mesos.cfg",
     "CKAN_DATASTORE_DB_USER": "datastore_default",
     "CKAN_SOLR_URL": "http://10.0.2.2:8983/solr",
+    "CKAN_SITE_URL": "http://localhost:$PORT0",
     "CKAN_DATASTORE_DB_NAME": "ckan_datastore",
     "CKAN_DB_USER": "ckan_default",
     "CKAN_POSTGRES_HOST": "10.0.2.2",

--- a/marathon_app.json
+++ b/marathon_app.json
@@ -1,0 +1,49 @@
+{
+  "id": "/dc-test",
+  "cmd": "env; cd ckan-installer-mesos/provisioners && ANSIBLE_CONFIG=ansible-mesos.cfg ansible-playbook -vvvv provision-mesos.yml ; httpd -DFOREGROUND -f \"$MESOS_SANDBOX/apache_ckan.conf\"; sleep 600",
+  "cpus": 1,
+  "mem": 100,
+  "disk": 800,
+  "instances": 1,
+  "env": {
+    "CKAN_DATASTORE_DB_USER": "datastore_default",
+    "CKAN_SOLR_URL": "http://10.0.2.2:8983/solr",
+    "CKAN_DATASTORE_DB_NAME": "ckan_datastore",
+    "CKAN_DB_USER": "ckan_default",
+    "CKAN_POSTGRES_HOST": "10.0.2.2",
+    "CKAN_DATASTORE_DB_PASSWORD": "your-super-secure-ckan-password!23",
+    "CKAN_DB_PASSWORD": "your-super-secure-ckan-password!23",
+    "CKAN_POSTGRES_PORT": "5432",
+    "CKAN_DB_NAME": "ckan"
+  },
+  "healthChecks": [
+    {
+      "path": ":8888/",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 3000,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 10000,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "uris": [
+    "https://github.com/mattboehm/ckan-installer/archive/mesos.tar.gz"
+  ],
+  "fetch": [
+    {
+      "uri": "https://github.com/mattboehm/ckan-installer/archive/mesos.tar.gz",
+      "extract": true,
+      "executable": false,
+      "cache": false
+    }
+  ]
+}

--- a/marathon_app.json
+++ b/marathon_app.json
@@ -1,8 +1,8 @@
 {
   "id": "/dc-test",
-  "cmd": "env; cd ckan-installer-mesos/provisioners && ansible-playbook -vvvv provision-mesos.yml ; httpd -DFOREGROUND -f \"$MESOS_SANDBOX/apache_ckan.conf\"; sleep 600",
-  "cpus": 0.5,
-  "mem": 128,
+  "cmd": "env; cd ckan-installer-master/provisioners && ansible-playbook -vvvv provision-mesos.yml ; source \"$MESOS_SANDBOX/ckan/default/bin/activate\"; uwsgi --http :$PORT0 --threads 8 --buffer-size 65535 --wsgi-file \"$MESOS_SANDBOX/ckan/config/default/apache.wsgi\"",
+  "cpus": 1,
+  "mem": 512,
   "disk": 0,
   "instances": 1,
   "env": {
@@ -16,7 +16,9 @@
     "CKAN_DATASTORE_DB_PASSWORD": "your-super-secure-ckan-password!23",
     "CKAN_DB_PASSWORD": "your-super-secure-ckan-password!23",
     "CKAN_POSTGRES_PORT": "5432",
-    "CKAN_DB_NAME": "ckan"
+    "CKAN_DB_NAME": "ckan",
+    "CKAN_REINDEX_SOLR": "True",
+    "CKAN_VERSION_TAG": "ckan-2.3"
   },
   "healthChecks": [
     {
@@ -37,12 +39,7 @@
       "labels": {}
     }
   ],
-  "fetch": [
-    {
-      "uri": "https://github.com/mattboehm/ckan-installer/archive/mesos.tar.gz",
-      "extract": true,
-      "executable": false,
-      "cache": false
-    }
+  "uris": [
+    "https://github.com/cfpb/ckan-installer/archive/master.tar.gz"
   ]
 }

--- a/marathon_app.json
+++ b/marathon_app.json
@@ -1,11 +1,12 @@
 {
   "id": "/dc-test",
-  "cmd": "env; cd ckan-installer-mesos/provisioners && ANSIBLE_CONFIG=ansible-mesos.cfg ansible-playbook -vvvv provision-mesos.yml ; httpd -DFOREGROUND -f \"$MESOS_SANDBOX/apache_ckan.conf\"; sleep 600",
-  "cpus": 1,
-  "mem": 100,
-  "disk": 800,
+  "cmd": "env; cd ckan-installer-mesos/provisioners && ansible-playbook -vvvv provision-mesos.yml ; httpd -DFOREGROUND -f \"$MESOS_SANDBOX/apache_ckan.conf\"; sleep 600",
+  "cpus": 0.5,
+  "mem": 128,
+  "disk": 0,
   "instances": 1,
   "env": {
+    "ANSIBLE_CONFIG": "ansible-mesos.cfg",
     "CKAN_DATASTORE_DB_USER": "datastore_default",
     "CKAN_SOLR_URL": "http://10.0.2.2:8983/solr",
     "CKAN_DATASTORE_DB_NAME": "ckan_datastore",
@@ -18,13 +19,13 @@
   },
   "healthChecks": [
     {
-      "path": ":8888/",
+      "path": "/",
       "protocol": "HTTP",
       "portIndex": 0,
-      "gracePeriodSeconds": 3000,
-      "intervalSeconds": 60,
-      "timeoutSeconds": 20,
-      "maxConsecutiveFailures": 3,
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 30,
+      "timeoutSeconds": 15,
+      "maxConsecutiveFailures": 40,
       "ignoreHttp1xx": false
     }
   ],

--- a/marathon_app.json
+++ b/marathon_app.json
@@ -35,9 +35,6 @@
       "labels": {}
     }
   ],
-  "uris": [
-    "https://github.com/mattboehm/ckan-installer/archive/mesos.tar.gz"
-  ],
   "fetch": [
     {
       "uri": "https://github.com/mattboehm/ckan-installer/archive/mesos.tar.gz",

--- a/provisioners/ansible-mesos.cfg
+++ b/provisioners/ansible-mesos.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = ../hosts/mesos_host
+local_tmp = $MESOS_SANDBOX/tmp
+remote_tmp = $MESOS_SANDBOX/remote_tmp

--- a/provisioners/group_vars/all
+++ b/provisioners/group_vars/all
@@ -4,3 +4,8 @@ ckan_venv: "{{ckan_install_dir}}/default"
 ckan_db_name: ckan
 ckan_datastore_db_name: ckan_datastore
 ckan_config_dir: /ckan/config/default
+apache_modules:
+  - name: log_config_module
+    path: "/usr/lib64/httpd/modules/mod_log_config.so"
+  - name: wsgi_module
+    path: "{{ckan_venv}}/lib/python2.7/site-packages/mod_wsgi/server/mod_wsgi-py27.so"

--- a/provisioners/group_vars/local
+++ b/provisioners/group_vars/local
@@ -1,6 +1,8 @@
 ---
 # Note: Try to minimize the number of group-specific variables
 
+# Whether you need to use sudo for creating ckan directories
+use_sudo: yes
 ckan_github_api_url: https://api.github.com/
 ckan_version_tag: ckan-2.3
 ckan_user: vagrant
@@ -18,5 +20,6 @@ ckan_force_reinstall_plugins: False
 ace_force_reinstall: False
 ckan_custom_plugins:
   - name: ckanext_cfpb_extrafields
+  #- name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import
     egg_name: ckanext_cfpb_extrafields
     url: https://github.com/cfpb/ckanext-cfpb-extrafields

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -44,6 +44,7 @@ postgres_login_host: "{{lookup('env', 'CKAN_POSTGRES_HOST')}}"
 postgres_port: "{{lookup('env', 'CKAN_POSTGRES_PORT')}}"
 
 solr_url: "{{lookup('env', 'CKAN_SOLR_URL')}}"
+ckan_reindex_solr: "{{lookup('env', 'CKAN_REINDEX_SOLR')|default(True, true)}}"
 
 ckan_custom_plugins:
   - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_sso

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -51,7 +51,7 @@ ckan_reindex_solr: "{{lookup('env', 'CKAN_REINDEX_SOLR')|default(True, true)}}"
 ckan_custom_plugins:
   - name: ldap
     egg_name: ckanext_ldap
-    url: "https://github.com/NaturalHistoryMuseum/ckanext-ldap"
+    url: "https://github.com/tanderegg/ckanext-ldap@digest_md5"
   - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import
     egg_name: ckanext_cfpb_extrafields
     url: "{{lookup('env', 'CKAN_CFPB_PLUGIN_URL')|default('https://github.com/cfpb/ckanext-cfpb-extrafields', true)}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -40,6 +40,8 @@ ckan_ldap_base_dn: "{{lookup('env', 'CKAN_LDAP_BASE_DN')}}"
 ckan_ldap_auth_dn: "{{lookup('env', 'CKAN_LDAP_AUTH_DN')}}"
 ckan_ldap_auth_password: "{{lookup('env', 'CKAN_LDAP_AUTH_PASSWORD')}}"
 
+file_permissions: "u+rw,g-w,o-rwx"
+
 postgres_login_host: "{{lookup('env', 'CKAN_POSTGRES_HOST')}}"
 postgres_port: "{{lookup('env', 'CKAN_POSTGRES_PORT')}}"
 

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -23,15 +23,15 @@ ckan_datastore_db_user: "{{lookup('env', 'CKAN_DATASTORE_DB_USER')}}"
 ckan_db_name: "{{lookup('env', 'CKAN_DB_NAME')}}"
 ckan_db_password: "{{lookup('env', 'CKAN_DB_PASSWORD')}}"
 ckan_db_user: "{{lookup('env', 'CKAN_DB_USER')}}"
-ckan_file_storage_dir: "/home/work/ckan/uploads"
+ckan_file_storage_dir: "{{lookup('env', 'CKAN_FILE_STORAGE_DIR')|default('/home/work/ckan/uploads')}}"
 ckan_force_reinstall_plugins: False
 ckan_github_api_url: "{{lookup('env', 'CKAN_GITHUB_API')|default('https://api.github.com/', true)}}"
-ckan_group: mesagent
+ckan_group: "{{lookup('env', 'CKAN_GROUP')|default('mesagent')}}"
 ckan_install_dir: "{{lookup('env', 'MESOS_SANDBOX')}}/ckan"
 ckan_log_dir: "{{ckan_install_dir}}/logs"
 ckan_config_dir: "{{ckan_install_dir}}/config/default"
 ckan_site_url: "{{lookup('env', 'CKAN_SITE_URL')}}/ckan"
-ckan_user: mesagent
+ckan_user: "{{lookup('env', 'CKAN_USER')|default('mesagent')}}"
 ckan_venv: "{{ckan_install_dir}}/default"
 ckan_version_tag: ckan-2.3
 

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -33,7 +33,7 @@ ckan_config_dir: "{{ckan_install_dir}}/config/default"
 ckan_site_url: "{{lookup('env', 'CKAN_SITE_URL')}}/ckan"
 ckan_user: "{{lookup('env', 'CKAN_USER')|default('mesagent', true)}}"
 ckan_venv: "{{ckan_install_dir}}/default"
-ckan_version_tag: ckan-2.3
+ckan_version_tag: "{{lookup('env', 'CKAN_VERSION_TAG')|default('ckan-2.3', true)}}"
 
 ckan_ldap_uri: "{{lookup('env', 'CKAN_LDAP_URI')}}"
 ckan_ldap_base_dn: "{{lookup('env', 'CKAN_LDAP_BASE_DN')}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -23,7 +23,7 @@ ckan_datastore_db_user: "{{lookup('env', 'CKAN_DATASTORE_DB_USER')}}"
 ckan_db_name: "{{lookup('env', 'CKAN_DB_NAME')}}"
 ckan_db_password: "{{lookup('env', 'CKAN_DB_PASSWORD')}}"
 ckan_db_user: "{{lookup('env', 'CKAN_DB_USER')}}"
-ckan_file_storage_dir: "{{lookup('env', 'CKAN_FILE_STORAGE_DIR')|default('/home/work/ckan/uploads')}}"
+ckan_file_storage_dir: "{{lookup('env', 'CKAN_FILE_STORAGE_DIR')|default('/home/work/ckan/uploads', true)}}"
 ckan_force_reinstall_plugins: False
 ckan_github_api_url: "{{lookup('env', 'CKAN_GITHUB_API')|default('https://api.github.com/', true)}}"
 ckan_group: "{{lookup('env', 'CKAN_GROUP')|default('mesagent', true)}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -23,7 +23,7 @@ ckan_datastore_db_user: "{{lookup('env', 'CKAN_DATASTORE_DB_USER')}}"
 ckan_db_name: "{{lookup('env', 'CKAN_DB_NAME')}}"
 ckan_db_password: "{{lookup('env', 'CKAN_DB_PASSWORD')}}"
 ckan_db_user: "{{lookup('env', 'CKAN_DB_USER')}}"
-ckan_file_storage_dir: "/home/dtwork/ckan/uploads"
+ckan_file_storage_dir: "/home/work/ckan/uploads"
 ckan_force_reinstall_plugins: False
 ckan_github_api_url: https://api.github.com/
 ckan_group: mesagent

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -46,6 +46,6 @@ postgres_port: "{{lookup('env', 'CKAN_POSTGRES_PORT')}}"
 solr_url: "{{lookup('env', 'CKAN_SOLR_URL')}}"
 
 ckan_custom_plugins:
-  - name: ckanext_cfpb_extrafields #ckanext_cfpb_export ckanext_cfpb_import
+  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_sso
     egg_name: ckanext_cfpb_extrafields
     url: https://github.com/cfpb/ckanext-cfpb-extrafields

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -51,4 +51,4 @@ ckan_reindex_solr: "{{lookup('env', 'CKAN_REINDEX_SOLR')|default(True, true)}}"
 ckan_custom_plugins:
   - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import ckanext_cfpb_sso
     egg_name: ckanext_cfpb_extrafields
-    url: https://github.com/cfpb/ckanext-cfpb-extrafields
+    url: "{{lookup('env', 'CKAN_CFPB_PLUGIN_URL')|default('https://github.com/cfpb/ckanext-cfpb-extrafields', true)}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -52,6 +52,6 @@ ckan_custom_plugins:
   - name: ldap
     egg_name: ckanext_ldap
     url: "https://github.com/tanderegg/ckanext-ldap@digest_md5"
-  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import
+  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import ckanext_cfpb_sso
     egg_name: ckanext_cfpb_extrafields
     url: "{{lookup('env', 'CKAN_CFPB_PLUGIN_URL')|default('https://github.com/cfpb/ckanext-cfpb-extrafields', true)}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -49,6 +49,6 @@ solr_url: "{{lookup('env', 'CKAN_SOLR_URL')}}"
 ckan_reindex_solr: "{{lookup('env', 'CKAN_REINDEX_SOLR')|default(True, true)}}"
 
 ckan_custom_plugins:
-  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_sso
+  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import ckanext_cfpb_sso
     egg_name: ckanext_cfpb_extrafields
     url: https://github.com/cfpb/ckanext-cfpb-extrafields

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -1,0 +1,45 @@
+---
+# Note: Try to minimize the number of group-specific variables
+
+use_sudo: no
+#TODO add apache module to local/all group_vars
+ace_force_reinstall: False
+
+apache_as_service: False
+apache_config_dir: "{{lookup('env', 'MESOS_SANDBOX')}}/apache_ckan.conf"
+apache_server_root: "{{lookup('env', 'MESOS_SANDBOX')}}/httpd"
+apache_port: 8888
+apache_run_wsgi_daemon: False
+apache_modules:
+  - name: log_config_module
+    path: "/usr/lib64/httpd/modules/mod_log_config.so"
+  - name: wsgi_module
+    path: "{{ckan_venv}}/lib/python2.7/site-packages/mod_wsgi/server/mod_wsgi-py27.so"
+
+ckan_create_user_via_web: True 
+ckan_datastore_db_name: "{{lookup('env', 'CKAN_DATASTORE_DB_NAME')}}"
+ckan_datastore_db_password: "{{lookup('env', 'CKAN_DATASTORE_DB_PASSWORD')}}"
+ckan_datastore_db_user: "{{lookup('env', 'CKAN_DATASTORE_DB_USER')}}"
+ckan_db_name: "{{lookup('env', 'CKAN_DB_NAME')}}"
+ckan_db_password: "{{lookup('env', 'CKAN_DB_PASSWORD')}}"
+ckan_db_user: "{{lookup('env', 'CKAN_DB_USER')}}"
+ckan_file_storage_dir: "/home/dtwork/ckan/uploads"
+ckan_force_reinstall_plugins: False
+ckan_github_api_url: https://api.github.com/
+ckan_group: mesagent
+ckan_install_dir: "{{lookup('env', 'MESOS_SANDBOX')}}/ckan"
+ckan_log_dir: "{{ckan_install_dir}}/logs"
+ckan_config_dir: "{{ckan_install_dir}}/config/default"
+ckan_user: mesagent
+ckan_venv: "{{ckan_install_dir}}/default"
+ckan_version_tag: ckan-2.3
+
+postgres_login_host: "{{lookup('env', 'CKAN_POSTGRES_HOST')}}"
+postgres_port: "{{lookup('env', 'CKAN_POSTGRES_PORT')}}"
+
+solr_url: "{{lookup('env', 'CKAN_SOLR_URL')}}"
+
+ckan_custom_plugins:
+  - name: ckanext_cfpb_extrafields #ckanext_cfpb_export ckanext_cfpb_import
+    egg_name: ckanext_cfpb_extrafields
+    url: https://github.com/cfpb/ckanext-cfpb-extrafields

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -26,12 +26,12 @@ ckan_db_user: "{{lookup('env', 'CKAN_DB_USER')}}"
 ckan_file_storage_dir: "{{lookup('env', 'CKAN_FILE_STORAGE_DIR')|default('/home/work/ckan/uploads')}}"
 ckan_force_reinstall_plugins: False
 ckan_github_api_url: "{{lookup('env', 'CKAN_GITHUB_API')|default('https://api.github.com/', true)}}"
-ckan_group: "{{lookup('env', 'CKAN_GROUP')|default('mesagent')}}"
+ckan_group: "{{lookup('env', 'CKAN_GROUP')|default('mesagent', true)}}"
 ckan_install_dir: "{{lookup('env', 'MESOS_SANDBOX')}}/ckan"
 ckan_log_dir: "{{ckan_install_dir}}/logs"
 ckan_config_dir: "{{ckan_install_dir}}/config/default"
 ckan_site_url: "{{lookup('env', 'CKAN_SITE_URL')}}/ckan"
-ckan_user: "{{lookup('env', 'CKAN_USER')|default('mesagent')}}"
+ckan_user: "{{lookup('env', 'CKAN_USER')|default('mesagent', true)}}"
 ckan_venv: "{{ckan_install_dir}}/default"
 ckan_version_tag: ckan-2.3
 

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -49,6 +49,6 @@ solr_url: "{{lookup('env', 'CKAN_SOLR_URL')}}"
 ckan_reindex_solr: "{{lookup('env', 'CKAN_REINDEX_SOLR')|default(True, true)}}"
 
 ckan_custom_plugins:
-  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import ckanext_cfpb_sso
+  - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import
     egg_name: ckanext_cfpb_extrafields
     url: "{{lookup('env', 'CKAN_CFPB_PLUGIN_URL')|default('https://github.com/cfpb/ckanext-cfpb-extrafields', true)}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -40,7 +40,7 @@ ckan_ldap_base_dn: "{{lookup('env', 'CKAN_LDAP_BASE_DN')}}"
 ckan_ldap_auth_dn: "{{lookup('env', 'CKAN_LDAP_AUTH_DN')}}"
 ckan_ldap_auth_password: "{{lookup('env', 'CKAN_LDAP_AUTH_PASSWORD')}}"
 
-file_permissions: "u+rw,g-w,o-rwx"
+file_permissions: "u+rw,g-w,o-w"
 
 postgres_login_host: "{{lookup('env', 'CKAN_POSTGRES_HOST')}}"
 postgres_port: "{{lookup('env', 'CKAN_POSTGRES_PORT')}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -49,6 +49,9 @@ solr_url: "{{lookup('env', 'CKAN_SOLR_URL')}}"
 ckan_reindex_solr: "{{lookup('env', 'CKAN_REINDEX_SOLR')|default(True, true)}}"
 
 ckan_custom_plugins:
+  - name: ldap
+    egg_name: ckanext_ldap
+    url: "https://github.com/NaturalHistoryMuseum/ckanext-ldap"
   - name: ckanext_cfpb_extrafields ckanext_cfpb_export ckanext_cfpb_import
     egg_name: ckanext_cfpb_extrafields
     url: "{{lookup('env', 'CKAN_CFPB_PLUGIN_URL')|default('https://github.com/cfpb/ckanext-cfpb-extrafields', true)}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -8,7 +8,7 @@ ace_force_reinstall: False
 apache_as_service: False
 apache_config_dir: "{{lookup('env', 'MESOS_SANDBOX')}}/apache_ckan.conf"
 apache_server_root: "{{lookup('env', 'MESOS_SANDBOX')}}/httpd"
-apache_port: 8888
+apache_port: "{{lookup('env', 'PORT0')}}"
 apache_run_wsgi_daemon: False
 apache_modules:
   - name: log_config_module

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -16,7 +16,7 @@ apache_modules:
   - name: wsgi_module
     path: "{{ckan_venv}}/lib/python2.7/site-packages/mod_wsgi/server/mod_wsgi-py27.so"
 
-ckan_create_user_via_web: True 
+ckan_create_user_via_web: False 
 ckan_datastore_db_name: "{{lookup('env', 'CKAN_DATASTORE_DB_NAME')}}"
 ckan_datastore_db_password: "{{lookup('env', 'CKAN_DATASTORE_DB_PASSWORD')}}"
 ckan_datastore_db_user: "{{lookup('env', 'CKAN_DATASTORE_DB_USER')}}"

--- a/provisioners/group_vars/mesos
+++ b/provisioners/group_vars/mesos
@@ -25,14 +25,20 @@ ckan_db_password: "{{lookup('env', 'CKAN_DB_PASSWORD')}}"
 ckan_db_user: "{{lookup('env', 'CKAN_DB_USER')}}"
 ckan_file_storage_dir: "/home/work/ckan/uploads"
 ckan_force_reinstall_plugins: False
-ckan_github_api_url: https://api.github.com/
+ckan_github_api_url: "{{lookup('env', 'CKAN_GITHUB_API')|default('https://api.github.com/', true)}}"
 ckan_group: mesagent
 ckan_install_dir: "{{lookup('env', 'MESOS_SANDBOX')}}/ckan"
 ckan_log_dir: "{{ckan_install_dir}}/logs"
 ckan_config_dir: "{{ckan_install_dir}}/config/default"
+ckan_site_url: "{{lookup('env', 'CKAN_SITE_URL')}}/ckan"
 ckan_user: mesagent
 ckan_venv: "{{ckan_install_dir}}/default"
 ckan_version_tag: ckan-2.3
+
+ckan_ldap_uri: "{{lookup('env', 'CKAN_LDAP_URI')}}"
+ckan_ldap_base_dn: "{{lookup('env', 'CKAN_LDAP_BASE_DN')}}"
+ckan_ldap_auth_dn: "{{lookup('env', 'CKAN_LDAP_AUTH_DN')}}"
+ckan_ldap_auth_password: "{{lookup('env', 'CKAN_LDAP_AUTH_PASSWORD')}}"
 
 postgres_login_host: "{{lookup('env', 'CKAN_POSTGRES_HOST')}}"
 postgres_port: "{{lookup('env', 'CKAN_POSTGRES_PORT')}}"

--- a/provisioners/provision-mesos.yml
+++ b/provisioners/provision-mesos.yml
@@ -1,0 +1,9 @@
+---
+# Provisions the CKAN VM from scratch for Mesos
+
+
+- hosts: mesos
+  gather_facts: False
+  roles:
+    - ckan
+    - ace

--- a/provisioners/roles/ace/tasks/main.yml
+++ b/provisioners/roles/ace/tasks/main.yml
@@ -4,14 +4,12 @@
 - name: determine whether ace-builds already exists and dont replace
   stat: path="{{ ckanext_static_dir }}/ace-builds"
   register: acedir
-  sudo: yes
 
 - name: git clone ACE to ckanext_static_dir (static-file folder)
   git: repo=https://github.com/ajaxorg/ace-builds.git
        dest="{{ckanext_static_dir}}/ace-builds/"
        version=v1.1.9
        force=yes
-  sudo: yes
   when: not (acedir.stat.isdir is defined and acedir.stat.isdir) or ace_force_reinstall
 
 - name: ensure correct ownership for ACE directory
@@ -21,5 +19,6 @@
       owner="{{ckan_user}}"
       group="{{ckan_group}}"
       recurse=true
-  notify: restart apache
-  sudo: yes
+  notify: restart ckan apache
+  become: yes
+  when: "{{use_sudo}}"

--- a/provisioners/roles/ckan/defaults/main.yml
+++ b/provisioners/roles/ckan/defaults/main.yml
@@ -49,3 +49,5 @@ ckan_force_reinstall_plugins: True
 
 # User Registration Settings (registration only allowed on local machines without LDAP)
 ckan_create_user_via_web: False
+
+file_permissions: "u+rw,g+r,o+r"

--- a/provisioners/roles/ckan/defaults/main.yml
+++ b/provisioners/roles/ckan/defaults/main.yml
@@ -9,7 +9,7 @@ ckan_server_alias: localhost
 ckan_file_storage_dir: "{{ckan_venv}}/uploads"
 ckan_log_dir: /var/log/ckan
 ckan_site_id: ckan
-ckan_site_url: ""
+ckan_site_url: "http://localhost:8080"
 
 # postgres settings
 postgres_login_host: localhost

--- a/provisioners/roles/ckan/defaults/main.yml
+++ b/provisioners/roles/ckan/defaults/main.yml
@@ -18,6 +18,16 @@ ckan_db_name: ckan
 ckan_db_user: svc_ckan
 ckan_datastore_db_name: ckan_datastore
 
+# apache settings
+apache_as_service: True
+apache_config_dir: "/etc/httpd/conf.d/ckan.conf"
+apache_modules:
+  - name: log_config_module
+    path: "/usr/lib64/httpd/modules/mod_log_config.so"
+apache_port: 80
+apache_run_wsgi_daemon: True
+apache_server_root: "/etc/httpd"
+
 # solr settings
 solr_url: http://127.0.0.1:8983/solr
 

--- a/provisioners/roles/ckan/defaults/main.yml
+++ b/provisioners/roles/ckan/defaults/main.yml
@@ -24,7 +24,7 @@ apache_config_dir: "/etc/httpd/conf.d/ckan.conf"
 apache_modules:
   - name: log_config_module
     path: "/usr/lib64/httpd/modules/mod_log_config.so"
-apache_port: 80
+apache_port: 8080
 apache_run_wsgi_daemon: True
 apache_server_root: "/etc/httpd"
 

--- a/provisioners/roles/ckan/defaults/main.yml
+++ b/provisioners/roles/ckan/defaults/main.yml
@@ -30,6 +30,7 @@ apache_server_root: "/etc/httpd"
 
 # solr settings
 solr_url: http://127.0.0.1:8983/solr
+ckan_reindex_solr: True
 
 # Email Settings
 ckan_email_to: ""

--- a/provisioners/roles/ckan/handlers/main.yml
+++ b/provisioners/roles/ckan/handlers/main.yml
@@ -1,6 +1,11 @@
 ---
 # handlers file for ckan
 - name: restart postgres
-  service: name=postgresql-9.4 state=restarted sleep=1
-  when: groups.has_key('local') and inventory_hostname in groups.local
-  sudo: yes
+  service: name=postgresql-9.4 state=restarted sleep=1 #TODO update to postgresql-9.5?
+  when: use_sudo and groups.has_key('local') and inventory_hostname in groups.local
+  become: yes
+
+- name: restart ckan apache
+  service: name=httpd state=restarted sleep=1
+  when: apache_as_service
+  become: yes

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -74,6 +74,9 @@
 - name: pip install mod_wsgi
   shell: "source {{ckan_venv}}/bin/activate && python -m pip install mod_wsgi"
 
+- name: pip install uwsgi
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install uwsgi"
+
 #Need to use python -m pip because when installing on mesos, you can't run pip directly due to the #! line being too long
 - name: pip install CKAN
   shell: "source {{ckan_venv}}/bin/activate && python -m pip install -e git+https://github.com/ckan/ckan.git@{{ckan_version_tag}}#egg=ckan"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -208,7 +208,7 @@
       owner="{{ckan_user}}"
       group="{{ckan_group}}"
       recurse=true
-      mode="{{file_permissions}}"
+      #mode="{{file_permissions}}"
   with_items:
     - "{{ckan_install_dir}}"
     - "{{ckan_config_dir}}"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -120,11 +120,18 @@
     group="{{ckan_group}}"
     recurse=yes
 
+- name: check if CKAN uploads directory exists
+  stat:
+    path: "{{ckan_file_storage_dir}}"
+  register: ckan_upload_dir_stat
+
 - name: create CKAN uploads directory
   file:
     path="{{ckan_file_storage_dir}}"
     state=directory
     recurse=yes
+  when: not ckan_upload_dir_stat.stat.exists
+
 # owner="{{ckan_user}}" #commented out for now as this breaks in staging due to multiple uids for mesagent user
 # group="{{ckan_group}}"
 

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -8,9 +8,8 @@
     - postgresql-devel
     - postgresql-libs
     - libselinux-python
-    # needed if installing ldap-based authentication
-    - python-ldap
-  sudo: yes
+  become: yes
+  when: "{{use_sudo}}"
 
 - name: create CKAN directory
   file:
@@ -20,30 +19,51 @@
     group="{{ckan_group}}"
     mode=0755
     recurse=yes
-  sudo: yes
+  become: "{{use_sudo}}"
 
+- name: create apache server root
+  file:
+    path="{{apache_server_root}}"
+    state=directory
+    owner="{{ckan_user}}"
+    group="{{ckan_group}}"
+    mode=0755
+    recurse=yes
+  become: "{{use_sudo}}"
+
+- name: create apache wsgi socket dir
+  file:
+    path="{{apache_server_root}}/sockets"
+    state=directory
+    owner="{{ckan_user}}"
+    group="{{ckan_group}}"
+    mode=0755
+    recurse=yes
+  become: "{{use_sudo}}"
+
+#Make the ckan venv
+- name: make the virtual environment
+  shell: "/usr/local/bin/virtualenv $(basename {{ckan_venv}})"
+  args:
+    creates: "{{ckan_venv}}"
+    chdir: "{{ckan_venv}}/.."
+
+#This version of python throws SNIMissingWarning unless an SNI extension to TLS is available
+- name: pip install ssl extensions
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install requests[security]"
+
+- name: pip install python-ldap
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install python-ldap"
+
+- name: pip install mod_wsgi
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install mod_wsgi"
+
+#Need to use python -m pip because when installing on mesos, you can't run pip directly due to the #! line being too long
 - name: pip install CKAN
-  pip: 
-    name="git+https://github.com/ckan/ckan.git@{{ckan_version_tag}}#egg=ckan"
-    virtualenv="{{ckan_venv}}"
-    virtualenv_site_packages=no
-    extra_args="-e"
-  environment: 
-    # Depending on the user running this command, we need
-    # to ensure /usr/local/bin is in the path so that 
-    # virtualenv is accessible.  
-    PATH: /usr/local/bin:/bin:/usr/bin
-  sudo: yes
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install -e git+https://github.com/ckan/ckan.git@{{ckan_version_tag}}#egg=ckan"
 
 - name: pip install CKAN requirements
-  pip:
-    requirements="{{ckan_venv}}/src/ckan/requirements.txt"
-    virtualenv="{{ckan_venv}}"
-  environment: 
-    # This is a bit of a hack so that we don't have to spend
-    # time gathering facts. We could just use anisble_env.PATH
-    PATH: /usr/pgsql-9.4/bin:/usr/local/bin:/bin:/usr/bin
-  sudo: yes
+  shell: "source {{ckan_venv}}/bin/activate && PATH=\"/usr/pgsql-9.4/bin:/usr/pgsql-9.5/bin:$PATH\" python -m pip install -r {{ckan_venv}}/src/ckan/requirements.txt"
 
 - name: check whether plugin has already been cloned
   stat:
@@ -51,7 +71,6 @@
   register: check_plugin_path
   with_items: "{{ckan_custom_plugins}}"
   when: ckan_custom_plugins is defined
-  sudo: yes
 
 - name: notification when skipping git clone
   debug: msg="plugin folder exists so cloning will be skipped!!"
@@ -60,36 +79,22 @@
 
 # TODO: Write a custom module that installs the custom plugins
 - name: pip install CKAN any custom plugins
-  pip: 
-    name="git+{{item.0.url}}#egg={{item.0.egg_name}}"
-    virtualenv="{{ckan_venv}}"
-    virtualenv_site_packages=no
-    extra_args="-e"
-  environment: 
-    # Depending on the user running this command, we need
-    # to ensure /usr/local/bin is in the path so that 
-    # virtualenv is accessible.  
-    PATH: /usr/local/bin:/bin:/usr/bin
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install -e git+{{item.0.url}}#egg={{item.0.egg_name}}"
   with_together:
     - "{{ckan_custom_plugins}}"
     - "{{check_plugin_path.results}}"
   when: ckan_custom_plugins is defined and check_plugin_path.results is defined and (item.1.stat.exists == false or ckan_force_reinstall_plugins)
-  sudo: yes
 
 - name: check if custom plugin has requirements.txt file
   stat: path="{{ckan_venv}}/src/{{item.egg_name|regex_replace('_', '-')}}/requirements.txt"
   with_items: "{{ckan_custom_plugins}}"
   when: ckan_custom_plugins is defined
   register: plugins_requirements
-  sudo: yes
 
 - name: pip install the requirements of custom plugins
-  pip:
-    requirements="{{ckan_venv}}/src/{{item.item.egg_name|regex_replace('_', '-')}}/requirements.txt"
-    virtualenv="{{ckan_venv}}"
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install -r {{ckan_venv}}/src/{{item.item.egg_name|regex_replace('_', '-')}}/requirements.txt"
   with_items: "{{plugins_requirements.results}}"
   when: item.stat.exists
-  sudo: yes
 
 - name: create CKAN config directory
   file:
@@ -97,7 +102,6 @@
     state=directory
     owner="{{ckan_user}}"
     group="{{ckan_group}}"
-  sudo: yes
 
 - name: create CKAN uploads directory
   file:
@@ -105,7 +109,6 @@
     state=directory
     owner="{{ckan_user}}"
     group="{{ckan_group}}"
-  sudo: yes
 
 - name: create CKAN log directory
   file:
@@ -113,27 +116,26 @@
     state=directory
     owner="{{ckan_user}}"
     group="{{ckan_group}}"
-  sudo: yes
+  become: "{{use_sudo}}"
 
 - name: create CKAN config file
   template: 
     src="config.ini.j2"
     dest="{{ckan_config_dir}}/config.ini"
-  notify: restart apache
-  sudo: yes
+  notify: restart ckan apache
 
 - name: set read-only ckan user
-  shell: source {{ckan_venv}}/bin/activate && paster --plugin=ckan datastore set-permissions -c {{ckan_config_dir}}/config.ini | sudo -u postgres psql --set ON_ERROR_STOP=1
+  shell: source {{ckan_venv}}/bin/activate && python {{ckan_venv}}/bin/paster --plugin=ckan datastore set-permissions -c {{ckan_config_dir}}/config.ini | sudo -u postgres psql --set ON_ERROR_STOP=1
     chdir="{{ckan_venv}}/src/ckan"
-  when: groups.has_key('local') and inventory_hostname in groups.local
+  when: use_sudo and groups.has_key('local') and inventory_hostname in groups.local
   #when: create_datastore_db|changed or create_datastore_db_user|changed or create_ckan_db|changed or create_ckan_db_user|changed
   notify: restart postgres
-  sudo: yes
 
+#TODO disable when not use_sudo?
 - name: create CKAN tables in database
-  shell: source {{ckan_venv}}/bin/activate && paster db init -c {{ckan_config_dir}}/config.ini
+  shell: source {{ckan_venv}}/bin/activate && python {{ckan_venv}}/bin/paster db init -c {{ckan_config_dir}}/config.ini
     chdir="{{ckan_venv}}/src/ckan"
-  sudo: yes
+  #sudo: yes
   #sudo_user: postgres
   #when: create_datastore_db|changed or create_datastore_db_user|changed or create_ckan_db|changed or create_ckan_db_user|changed
   notify: restart postgres
@@ -143,22 +145,21 @@
     src={{ckan_venv}}/src/ckan/who.ini
     dest={{ckan_config_dir}}/who.ini
     state=link
-  sudo: yes
 
 - name: create CKAN wsgi file
   template: 
     src="apache.wsgi.j2"
     dest="{{ckan_config_dir}}/apache.wsgi"
     mode=0755
-  notify: restart apache
-  sudo: yes
+  notify: restart ckan apache
 
+#TODO also support uwsgi
 - name: create CKAN apache config file
   template:
     src="ckan.conf.j2"
-    dest="/etc/httpd/conf.d/ckan.conf"
-  sudo: yes
-  notify: restart apache
+    dest="{{apache_config_dir}}"
+  become: "{{use_sudo}}"
+  notify: restart ckan apache
 
 - name: ensure correct ownership for all ckan directories
   file:
@@ -171,12 +172,13 @@
     - "{{ckan_install_dir}}"
     - "{{ckan_config_dir}}"
     - "{{ckan_log_dir}}"
-  notify: restart apache
-  sudo: yes
+  notify: restart ckan apache
 
+#I think this was a feature started on that was never completed. For now, only enable it in dev environment
 - name: create crontab for sending activity stream emails
   cron: name="ckan_send_emails"
         minute={{ckan_email_flush_interval}}
-        job="echo $(date) >> {{ckan_log_dir}}/email_flush.log && echo '{}' | {{ckan_venv}}/bin/paster post -c {{ckan_config_dir}}/config.ini /api/action/send_email_notifications >> {{ckan_log_dir}}/email_flush.log && echo '' >> {{ckan_log_dir}}/email_flush.log"
+        job="echo $(date) >> {{ckan_log_dir}}/email_flush.log && echo '{}' | {{ckan_venv}}/bin/python {{ckan_venv}}/bin/paster post -c {{ckan_config_dir}}/config.ini /api/action/send_email_notifications >> {{ckan_log_dir}}/email_flush.log && echo '' >> {{ckan_log_dir}}/email_flush.log"
         user=root
-  sudo: yes
+  become: yes
+  when: "{{use_sudo}}"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -77,12 +77,14 @@
 - name: pip install uwsgi
   shell: "source {{ckan_venv}}/bin/activate && python -m pip install uwsgi"
 
-#Need to use python -m pip because when installing on mesos, you can't run pip directly due to the #! line being too long
+# Need to use python -m pip because when installing on mesos, you can't run pip directly due to the #! line being too long
 - name: pip install CKAN
   shell: "source {{ckan_venv}}/bin/activate && python -m pip install -e git+https://github.com/ckan/ckan.git@{{ckan_version_tag}}#egg=ckan"
 
 - name: pip install CKAN requirements
-  shell: "source {{ckan_venv}}/bin/activate && PATH=\"/usr/pgsql-9.4/bin:/usr/pgsql-9.5/bin:$PATH\" python -m pip install -r {{ckan_venv}}/src/ckan/requirements.txt"
+  shell: "source {{ckan_venv}}/bin/activate && python -m pip install -r {{ckan_venv}}/src/ckan/requirements.txt"
+  environment:
+    PATH: /usr/pgsql-9.4/bin:/usr/pgsql-9.5/bin:{{ansible_env.PATH}}
 
 - name: check whether plugin has already been cloned
   stat:
@@ -165,9 +167,6 @@
 - name: create CKAN tables in database
   shell: source {{ckan_venv}}/bin/activate && python {{ckan_venv}}/bin/paster db init -c {{ckan_config_dir}}/config.ini
     chdir="{{ckan_venv}}/src/ckan"
-  #sudo: yes
-  #sudo_user: postgres
-  #when: create_datastore_db|changed or create_datastore_db_user|changed or create_ckan_db|changed or create_ckan_db_user|changed
   notify: restart postgres
 
 - name: upgrade CKAN tables in database
@@ -193,7 +192,6 @@
     mode=0755
   notify: restart ckan apache
 
-#TODO also support uwsgi
 - name: create CKAN apache config file
   template:
     src="ckan.conf.j2"
@@ -216,7 +214,7 @@
   become: "{{use_sudo}}"
   notify: restart ckan apache
 
-#I think this was a feature started on that was never completed. For now, only enable it in dev environment
+# I think this was a feature started on that was never completed. For now, only enable it in dev environment
 - name: create crontab for sending activity stream emails
   cron: name="ckan_send_emails"
         minute={{ckan_email_flush_interval}}

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -124,11 +124,13 @@
     recurse=yes
 
 - name: check if CKAN uploads directory exists
+  ignore_errors: true
   stat:
     path: "{{ckan_file_storage_dir}}"
   register: ckan_upload_dir_stat
 
 - name: create CKAN uploads directory
+  ignore_errors: true
   file:
     path="{{ckan_file_storage_dir}}"
     state=directory

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -124,9 +124,9 @@
   file:
     path="{{ckan_file_storage_dir}}"
     state=directory
-    #owner="{{ckan_user}}" #commented out for now as this breaks in staging due to multiple uids for mesagent user
-    #group="{{ckan_group}}"
     recurse=yes
+# owner="{{ckan_user}}" #commented out for now as this breaks in staging due to multiple uids for mesagent user
+# group="{{ckan_group}}"
 
 - name: create CKAN log directory
   file:

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -159,7 +159,6 @@
   #when: create_datastore_db|changed or create_datastore_db_user|changed or create_ckan_db|changed or create_ckan_db_user|changed
   notify: restart postgres
 
-#TODO disable when not use_sudo?
 - name: create CKAN tables in database
   shell: source {{ckan_venv}}/bin/activate && python {{ckan_venv}}/bin/paster db init -c {{ckan_config_dir}}/config.ini
     chdir="{{ckan_venv}}/src/ckan"
@@ -167,6 +166,16 @@
   #sudo_user: postgres
   #when: create_datastore_db|changed or create_datastore_db_user|changed or create_ckan_db|changed or create_ckan_db_user|changed
   notify: restart postgres
+
+- name: upgrade CKAN tables in database
+  shell: source {{ckan_venv}}/bin/activate && python {{ckan_venv}}/bin/paster db upgrade -c {{ckan_config_dir}}/config.ini
+    chdir="{{ckan_venv}}/src/ckan"
+  notify: restart postgres
+
+- name: re-index solr instance
+  shell: source {{ckan_venv}}/bin/activate && python {{ckan_venv}}/bin/paster search-index rebuild -r --config={{ckan_config_dir}}/config.ini
+    chdir="{{ckan_venv}}/src/ckan"
+  when: "{{ckan_reindex_solr}}"
 
 - name: create symlink to who.ini
   file: 

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -112,6 +112,7 @@
     state=directory
     owner="{{ckan_user}}"
     group="{{ckan_group}}"
+    recurse=yes
 
 - name: create CKAN uploads directory
   file:
@@ -119,6 +120,7 @@
     state=directory
     owner="{{ckan_user}}"
     group="{{ckan_group}}"
+    recurse=yes
 
 - name: create CKAN log directory
   file:
@@ -126,6 +128,7 @@
     state=directory
     owner="{{ckan_user}}"
     group="{{ckan_group}}"
+    recurse=yes
   become: "{{use_sudo}}"
 
 - name: create CKAN config file

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -205,6 +205,7 @@
       owner="{{ckan_user}}"
       group="{{ckan_group}}"
       recurse=true
+      mode=0740
   with_items:
     - "{{ckan_install_dir}}"
     - "{{ckan_config_dir}}"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -129,6 +129,8 @@
   file:
     path="{{ckan_file_storage_dir}}"
     state=directory
+    owner="{{ckan_user}}"
+    group="{{ckan_group}}"
     recurse=yes
   when: not ckan_upload_dir_stat.stat.exists
 

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -205,7 +205,7 @@
       owner="{{ckan_user}}"
       group="{{ckan_group}}"
       recurse=true
-      mode=0740
+      mode="{{file_permissions}}"
   with_items:
     - "{{ckan_install_dir}}"
     - "{{ckan_config_dir}}"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -172,6 +172,7 @@
     - "{{ckan_install_dir}}"
     - "{{ckan_config_dir}}"
     - "{{ckan_log_dir}}"
+  become: "{{use_sudo}}"
   notify: restart ckan apache
 
 #I think this was a feature started on that was never completed. For now, only enable it in dev environment

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -31,6 +31,16 @@
     recurse=yes
   become: "{{use_sudo}}"
 
+- name: create apache run dir
+  file:
+    path="{{apache_server_root}}/run"
+    state=directory
+    owner="{{ckan_user}}"
+    group="{{ckan_group}}"
+    mode=0755
+    recurse=yes
+  become: "{{use_sudo}}"
+
 - name: create apache wsgi socket dir
   file:
     path="{{apache_server_root}}/sockets"

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -82,9 +82,7 @@
   shell: "source {{ckan_venv}}/bin/activate && python -m pip install -e git+https://github.com/ckan/ckan.git@{{ckan_version_tag}}#egg=ckan"
 
 - name: pip install CKAN requirements
-  shell: "source {{ckan_venv}}/bin/activate && python -m pip install -r {{ckan_venv}}/src/ckan/requirements.txt"
-  environment:
-    PATH: /usr/pgsql-9.4/bin:/usr/pgsql-9.5/bin:{{ansible_env.PATH}}
+  shell: "source {{ckan_venv}}/bin/activate && PATH=\"/usr/pgsql-9.4/bin:/usr/pgsql-9.5/bin:$PATH\" python -m pip install -r {{ckan_venv}}/src/ckan/requirements.txt"
 
 - name: check whether plugin has already been cloned
   stat:

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -31,6 +31,11 @@
     recurse=yes
   become: "{{use_sudo}}"
 
+- name: check if apache run dir exists
+  stat:
+    path: "{{apache_server_root}}/run"
+  register: apache_run_dir_stat
+
 - name: create apache run dir
   file:
     path="{{apache_server_root}}/run"
@@ -39,6 +44,7 @@
     group="{{ckan_group}}"
     mode=0755
     recurse=yes
+  when: not apache_run_dir_stat.stat.exists
   become: "{{use_sudo}}"
 
 - name: create apache wsgi socket dir

--- a/provisioners/roles/ckan/tasks/main.yml
+++ b/provisioners/roles/ckan/tasks/main.yml
@@ -124,8 +124,8 @@
   file:
     path="{{ckan_file_storage_dir}}"
     state=directory
-    owner="{{ckan_user}}"
-    group="{{ckan_group}}"
+    #owner="{{ckan_user}}" #commented out for now as this breaks in staging due to multiple uids for mesagent user
+    #group="{{ckan_group}}"
     recurse=yes
 
 - name: create CKAN log directory

--- a/provisioners/roles/ckan/templates/ckan.conf.j2
+++ b/provisioners/roles/ckan/templates/ckan.conf.j2
@@ -1,7 +1,15 @@
-LoadModule wsgi_module /usr/local/lib/python2.7/site-packages/mod_wsgi/server/mod_wsgi-py27.so
-WSGISocketPrefix /var/run/wsgi
+{% for module in apache_modules %}
+LoadModule {{module.name}} {{module.path}}
+{% endfor %}
 
-<VirtualHost 0.0.0.0:80>
+ServerRoot {{apache_server_root}}
+WSGISocketPrefix sockets/wsgi
+
+ErrorLog apache.error.log
+CustomLog apache.custom.log combined
+
+Listen {{apache_port}}
+<VirtualHost 0.0.0.0:{{apache_port}}>
     ServerName {{ckan_server_name}}
     ServerAlias {{ckan_server_alias}}
     WSGIScriptAlias / {{ckan_config_dir}}/apache.wsgi
@@ -10,10 +18,12 @@ WSGISocketPrefix /var/run/wsgi
     WSGIPassAuthorization On
 
     # Deploy as a daemon (avoids conflicts between CKAN instances).
+    {% if apache_run_wsgi_daemon %}
     WSGIDaemonProcess ckan_default user={{ckan_user}} group={{ckan_group}} display-name=ckan_default processes=2 threads=15 
 
     WSGIProcessGroup ckan_default
-
-    ErrorLog /var/log/httpd/ckan_default.error.log
-    CustomLog /var/log/httpd/ckan_default.custom.log combined
+    {% endif %}
+    #XXX: This put logs relative to SERVER_ROOT, which is /etc/httpd for non-mesos
+    ErrorLog ckan_default.error.log
+    CustomLog ckan_default.custom.log combined
 </VirtualHost>

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -61,7 +61,7 @@ ckan.site_url = {{ckan_site_url}}
 ckan.ckanext_cfpb_extrafields.github_api_url = {{ckan_github_api_url}}
 
 ## LDAP Settings
-{% if ckan_ldap_uri %}
+{% if ckan_ldap_uri is defined %}
 ckanext.ldap.uri = {{ckan_ldap_uri}}
 ckanext.ldap.base_dn = {{ckan_ldap_base_dn}}
 ckanext.ldap.auth.dn = {{ckan_ldap_auth_dn}}

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -59,6 +59,14 @@ ckan.site_url = {{ckan_site_url}}
 
 ## GitHub Enterprise settings
 ckan.ckanext_cfpb_extrafields.github_api_url = {{ckan_github_api_url}}
+
+## LDAP Settings
+{% if ckan_ldap_uri %}
+ckanext.ldap.uri = {{ckan_ldap_uri}}
+ckanext.ldap.base_dn = {{ckan_ldap_base_dn}}
+ckanext.ldap.auth.dn = {{ckan_ldap_auth_dn}}
+ckanext.ldap.auth.password = {{ckan_ldap_auth_password}}
+{% endif %}
     
 ## Authorization Settings
 

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -43,10 +43,10 @@ who.log_file = %(cache_dir)s/who_log.ini
 
 
 ## Database Settings
-sqlalchemy.url = postgresql://{{ckan_db_user}}:{{ckan_db_password}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_db_name}}
+sqlalchemy.url = postgresql://{{ckan_db_user}}:{{ckan_db_password|urlencode}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_db_name}}
 
-ckan.datastore.write_url = postgresql://{{ckan_db_user}}:{{ckan_db_password}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
-ckan.datastore.read_url = postgresql://{{ckan_datastore_db_user}}:{{ckan_datastore_db_password}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
+ckan.datastore.write_url = postgresql://{{ckan_db_user}}:{{ckan_db_password|urlencode}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
+ckan.datastore.read_url = postgresql://{{ckan_datastore_db_user}}:{{ckan_datastore_db_password|urlencode}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
 
 # PostgreSQL' full-text search parameters
 ckan.datastore.default_fts_lang = english

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -68,7 +68,7 @@ ckanext.ldap.auth.dn = {{ckan_ldap_auth_dn}}
 ckanext.ldap.auth.password = {{ckan_ldap_auth_password}}
 {% endif %}
     
-ckanext.cfpb_sso.http_header = "X-REMOTE-USER"
+ckanext.cfpb_sso.http_header = X-Remote-User
 
 ## Authorization Settings
 

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -43,10 +43,10 @@ who.log_file = %(cache_dir)s/who_log.ini
 
 
 ## Database Settings
-sqlalchemy.url = postgresql://{{ckan_db_user}}:{{ckan_db_password|urlencode}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_db_name}}
+sqlalchemy.url = postgresql://{{ckan_db_user}}:{{ckan_db_password}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_db_name}}
 
-ckan.datastore.write_url = postgresql://{{ckan_db_user}}:{{ckan_db_password|urlencode}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
-ckan.datastore.read_url = postgresql://{{ckan_datastore_db_user}}:{{ckan_datastore_db_password|urlencode}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
+ckan.datastore.write_url = postgresql://{{ckan_db_user}}:{{ckan_db_password}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
+ckan.datastore.read_url = postgresql://{{ckan_datastore_db_user}}:{{ckan_datastore_db_password}}@{{postgres_login_host}}:{{postgres_port}}/{{ckan_datastore_db_name}}
 
 # PostgreSQL' full-text search parameters
 ckan.datastore.default_fts_lang = english

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -66,6 +66,11 @@ ckanext.ldap.uri = {{ckan_ldap_uri}}
 ckanext.ldap.base_dn = {{ckan_ldap_base_dn}}
 ckanext.ldap.auth.dn = {{ckan_ldap_auth_dn}}
 ckanext.ldap.auth.password = {{ckan_ldap_auth_password}}
+ckanext.ldap.auth.method = SASL
+ckanext.ldap.search.filter = sAMAccountName={login}
+ckanext.ldap.username = sAMAccountName
+ckanext.ldap.fullname = displayName
+ckanext.ldap.email = mail
 {% endif %}
     
 ckanext.cfpb_sso.http_header = X-Remote-User

--- a/provisioners/roles/ckan/templates/config.ini.j2
+++ b/provisioners/roles/ckan/templates/config.ini.j2
@@ -68,6 +68,8 @@ ckanext.ldap.auth.dn = {{ckan_ldap_auth_dn}}
 ckanext.ldap.auth.password = {{ckan_ldap_auth_password}}
 {% endif %}
     
+ckanext.cfpb_sso.http_header = "X-REMOTE-USER"
+
 ## Authorization Settings
 
 ckan.auth.anon_create_dataset = false


### PR DESCRIPTION
Running `ansible-playbook provision-mesos.yml` will install onto mesos

* Read many vars from the env
* Don't use sudo
* Only run ckan/ace tasks
* Run apache in the foreground
* Store all files in MESOS_SANDBOX (and store ckan user uploads on the network drive)
